### PR TITLE
Create certs directory

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -10,6 +10,7 @@ if [ ! -f /etc/nginx-certs/server.pem ] || [ ! -f /etc/nginx-certs/server.key ];
     openssl req -new -key server.key -out server.csr \
     -subj "/C=XX/ST=X/L=X/O=X/OU=X/CN=example.com"
     openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+    mkdir /etc/nginx-certs/
     cp server.key /etc/nginx-certs/server.key
     cp server.crt /etc/nginx-certs/server.pem
 fi


### PR DESCRIPTION
Hi there,

Here is my logs when I'm trying to run your image with the following command :
`docker run --name piwik --link mysql:db_1 -e DB_USER=bzzbzz -e DB_PASSWORD=bzzbzz -e DB_NAME=piwik -e PIWIK_USER=bzzbzz -e PIWIK_PASSWORD=bzzbzz -p 8084:80 -d bprodoehl/piwik`

```
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/05-certs.sh...
[...]
Getting Private key
cp: cannot create regular file '/etc/nginx-certs/server.key': No such file or directory
cp: cannot create regular file '/etc/nginx-certs/server.pem': No such file or directory
*** /etc/my_init.d/05-certs.sh failed with status 1
*** Killing all processes...
```

I just add the creation of the `/etc/nginx-certs` folder. If you think it's not an issue from your image, just close it :)
