### PR TITLE
Create directory for nginx cert

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -10,6 +10,7 @@ if [ ! -f /etc/nginx-certs/server.pem ] || [ ! -f /etc/nginx-certs/server.key ];
     openssl req -new -key server.key -out server.csr \
     -subj "/C=XX/ST=X/L=X/O=X/OU=X/CN=example.com"
     openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+    mkdir /etc/nginx-certs
     cp server.key /etc/nginx-certs/server.key
     cp server.crt /etc/nginx-certs/server.pem
 fi


### PR DESCRIPTION
Hi,

when running the docker container it fails with:

```
cp: cannot create regular file '/etc/nginx-certs/server.key': No such file or directory
cp: cannot create regular file '/etc/nginx-certs/server.pem': No such file or directory
*** /etc/my_init.d/05-certs.sh failed with status 1
```

because the directory `/etc/nginx--certs` is non existent as no one creates it.

regards,
Patrick
