### PR TITLE
update Dockerfile for newest Piwik and installation tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get -y dist-upgrade
 
 RUN echo "deb http://ppa.launchpad.net/nginx/development/ubuntu $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nginx-development.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C
+RUN add-apt-repository universe && add-apt-repository multiverse
 RUN apt-get update -q && \
     apt-get install -qy mysql-client nginx php5-cli php5-gd php5-fpm php5-json \
                         php5-mysql php5-curl wget && \
@@ -26,14 +27,13 @@ ADD config/nginx-default.conf /etc/nginx/sites-available/default
 ADD config/php.ini /etc/php5/fpm/php.ini
 
 RUN cd /usr/share/nginx/html && \
-    export PIWIK_VERSION=2.10.0 && \
+    export PIWIK_VERSION=2.14.3 && \
     wget http://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz && \
     tar -xzf piwik-${PIWIK_VERSION}.tar.gz && \
     rm piwik-${PIWIK_VERSION}.tar.gz && \
     mv piwik/* . && \
     rm -r piwik && \
     chown -R www-data:www-data /usr/share/nginx/html && \
-    mkdir /usr/share/nginx/html/tmp && \
     chmod 0770 /usr/share/nginx/html/tmp && \
     chmod 0770 /usr/share/nginx/html/config && \
     chmod 0600 /usr/share/nginx/html/config/* && \


### PR DESCRIPTION
- php5-fpm depended on another php5-common version than available
- nginx/tmp folder already existed and thus couldn't be created anymore

@bprodoehl Please verify yourself and merge at will.
